### PR TITLE
Clean up WriteState

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -151,7 +151,7 @@ enum WriteState {
 
 enum NextWriteState {
     Same,
-    None,
+    Nothing,
     Next(WriteState),
 }
 
@@ -198,7 +198,7 @@ impl WriteState {
                     Ok(WriterResult::Continue) => NextWriteState::Same,
                     Err(e) => {
                         debug!("WriteId {:?}: write err, {:?}", token, e);
-                        NextWriteState::None
+                        NextWriteState::Nothing
                     },
                 }
             }
@@ -211,13 +211,13 @@ impl WriteState {
                             NextWriteState::Next(WriteState::WriteData(payload))
                         } else {
                             debug!("WriteSize {:?}: no payload to write.", token);
-                            NextWriteState::None
+                            NextWriteState::Nothing
                         }
                     },
                     Ok(WriterResult::Continue) => NextWriteState::Same,
                     Err(e) => {
                         debug!("WriteSize {:?}: write err, {:?}", token, e);
-                        NextWriteState::None
+                        NextWriteState::Nothing
                     },
                 }
             }
@@ -225,19 +225,19 @@ impl WriteState {
                 match payload.try_write(socket) {
                     Ok(WriterResult::Done) => {
                         debug!("WriteData {:?}: done writing payload", token);
-                        NextWriteState::None
+                        NextWriteState::Nothing
                     }
                     Ok(WriterResult::Continue) => NextWriteState::Same,
                     Err(e) => {
                         debug!("WriteData {:?}: write err, {:?}", token, e);
-                        NextWriteState::None
+                        NextWriteState::Nothing
                     },
                 }
             }
         };
         match update {
             NextWriteState::Next(next) => *state = Some(next),
-            NextWriteState::None => {
+            NextWriteState::Nothing => {
                 *state = None;
                 debug!("WriteSize {:?}: Done writing.", token);
                 if outbound.is_empty() {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -82,7 +82,7 @@ impl<D> Writer<D>
     fn try_write(&mut self, stream: &mut TcpStream) -> io::Result<WriterResult> {
         match stream.try_write(&mut self.data.range_from(self.written)) {
             Ok(None) => {
-                debug!("Spurious wakeup, {}/{}", self.written,self.data.len());
+                debug!("Spurious wakeup, {}/{}", self.written, self.data.len());
                 Ok(WriterResult::Continue)
             }
             Ok(Some(bytes_written)) => {


### PR DESCRIPTION
- Create `Writer` class, which deals directly writing both vecs and u8s to the socket
- Replace `Option<Option<WriteState>>` with an enum
- Fix some interest handling
