### PR TITLE
[WIP] Update to futures-preview 0.3.0-alpha.7

### DIFF
--- a/bincode-transport/Cargo.toml
+++ b/bincode-transport/Cargo.toml
@@ -19,10 +19,10 @@ tokio-tcp = "0.1"
 tokio-serde = "0.2"
 
 [target.'cfg(not(test))'.dependencies]
-futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.6", features = ["compat"] }
 
 [dev-dependencies]
-futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs", features = ["compat", "tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
 env_logger = "0.5"
 humantime = "1.0"
 log = "0.4"

--- a/bincode-transport/Cargo.toml
+++ b/bincode-transport/Cargo.toml
@@ -19,10 +19,10 @@ tokio-tcp = "0.1"
 tokio-serde = "0.2"
 
 [target.'cfg(not(test))'.dependencies]
-futures-preview = { version = "0.3.0-alpha.6", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.7", features = ["compat"] }
 
 [dev-dependencies]
-futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.7", features = ["compat", "tokio-compat"] }
 env_logger = "0.5"
 humantime = "1.0"
 log = "0.4"

--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bincode-transport = { path = "../bincode-transport" }
-futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.7", features = ["compat", "tokio-compat"] }
 serde = { version = "1.0" }
 tarpc = { path = "../tarpc", features = ["serde"] }
 tarpc-plugins = { path = "../plugins" }

--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bincode-transport = { path = "../bincode-transport" }
-futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs", features = ["compat", "tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
 serde = { version = "1.0" }
 tarpc = { path = "../tarpc", features = ["serde"] }
 tarpc-plugins = { path = "../plugins" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -22,10 +22,10 @@ trace = { path = "../trace" }
 serde = { optional = true, version = "1.0" }
 
 [target.'cfg(not(test))'.dependencies]
-futures-preview = { version = "0.3.0-alpha.6", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.7", features = ["compat"] }
 
 [dev-dependencies]
-futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
-futures-test-preview = { version = "0.3.0-alpha.6" }
+futures-preview = { version = "0.3.0-alpha.7", features = ["compat", "tokio-compat"] }
+futures-test-preview = { version = "0.3.0-alpha.7" }
 env_logger = "0.5"
 tokio = "0.1"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -22,10 +22,10 @@ trace = { path = "../trace" }
 serde = { optional = true, version = "1.0" }
 
 [target.'cfg(not(test))'.dependencies]
-futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.6", features = ["compat"] }
 
 [dev-dependencies]
-futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs", features = ["compat", "tokio-compat"] }
-futures-test-preview = { git = "https://github.com/rust-lang-nursery/futures-rs" }
+futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
+futures-test-preview = { version = "0.3.0-alpha.6" }
 env_logger = "0.5"
 tokio = "0.1"

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -8,6 +8,7 @@ use fnv::FnvHashMap;
 use futures::{
     channel::mpsc,
     future::{abortable, AbortHandle},
+    Poll,
     prelude::*,
     ready,
     stream::Fuse,
@@ -21,7 +22,9 @@ use std::{
     io,
     marker::PhantomData,
     net::SocketAddr,
-    pin::PinMut,
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    task::LocalWaker,
     time::{Instant, SystemTime},
 };
 use tokio_timer::timeout;
@@ -120,12 +123,12 @@ where
 {
     type Output = ();
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<()> {
-        while let Some(channel) = ready!(self.incoming().poll_next(cx)) {
+    fn poll(mut self: Pin<Self>, lw: &LocalWaker) -> Poll<()> {
+        while let Some(channel) = ready!(self.incoming().poll_next(lw)) {
             match channel {
                 Ok(channel) => {
                     let peer = channel.client_addr;
-                    if let Err(e) = cx
+                    if let Err(e) = lw
                         .spawner()
                         .spawn(channel.respond_with(self.request_handler().clone()))
                     {
@@ -217,29 +220,29 @@ where
     Req: Send,
     Resp: Send,
 {
-    pub(crate) fn start_send(self: &mut PinMut<Self>, response: Response<Resp>) -> io::Result<()> {
+    pub(crate) fn start_send(self: &mut Pin<Self>, response: Response<Resp>) -> io::Result<()> {
         self.transport().start_send(response)
     }
 
     pub(crate) fn poll_ready(
-        self: &mut PinMut<Self>,
-        cx: &mut task::Context,
+        self: &mut Pin<Self>,
+        lw: &LocalWaker,
     ) -> Poll<io::Result<()>> {
-        self.transport().poll_ready(cx)
+        self.transport().poll_ready(lw)
     }
 
     pub(crate) fn poll_flush(
-        self: &mut PinMut<Self>,
-        cx: &mut task::Context,
+        self: &mut Pin<Self>,
+        lw: &LocalWaker,
     ) -> Poll<io::Result<()>> {
-        self.transport().poll_flush(cx)
+        self.transport().poll_flush(lw)
     }
 
     pub(crate) fn poll_next(
-        self: &mut PinMut<Self>,
-        cx: &mut task::Context,
+        self: &mut Pin<Self>,
+        lw: &LocalWaker,
     ) -> Poll<Option<io::Result<ClientMessage<Req>>>> {
-        self.transport().poll_next(cx)
+        self.transport().poll_next(lw)
     }
 
     /// Returns the address of the client connected to the channel.
@@ -291,7 +294,7 @@ impl<Req, Resp, T, F> ClientHandler<Req, Resp, T, F> {
     unsafe_pinned!(pending_responses: Fuse<mpsc::Receiver<(Context, Response<Resp>)>>);
     unsafe_pinned!(responses_tx: mpsc::Sender<(Context, Response<Resp>)>);
     // For this to be safe, field f must be private, and code in this module must never
-    // construct PinMut<F>.
+    // construct Pin<F>.
     unsafe_unpinned!(f: F);
 }
 
@@ -306,34 +309,34 @@ where
     /// If at max in-flight requests, check that there's room to immediately write a throttled
     /// response.
     fn poll_ready_if_throttling(
-        self: &mut PinMut<Self>,
-        cx: &mut task::Context,
+        self: &mut Pin<Self>,
+        lw: &LocalWaker,
     ) -> Poll<io::Result<()>> {
         if self.in_flight_requests.len()
             >= self.channel.config.max_in_flight_requests_per_connection
         {
             let peer = self.channel().client_addr;
 
-            while let Poll::Pending = self.channel().poll_ready(cx)? {
+            while let Poll::Pending = self.channel().poll_ready(lw)? {
                 info!(
                     "[{}] In-flight requests at max ({}), and transport is not ready.",
                     peer,
                     self.in_flight_requests().len(),
                 );
-                try_ready!(self.channel().poll_flush(cx));
+                try_ready!(self.channel().poll_flush(lw));
             }
         }
         Poll::Ready(Ok(()))
     }
 
-    fn pump_read(self: &mut PinMut<Self>, cx: &mut task::Context) -> Poll<Option<io::Result<()>>> {
-        ready!(self.poll_ready_if_throttling(cx)?);
+    fn pump_read(self: &mut Pin<Self>, lw: &LocalWaker) -> Poll<Option<io::Result<()>>> {
+        ready!(self.poll_ready_if_throttling(lw)?);
 
-        Poll::Ready(match ready!(self.channel().poll_next(cx)?) {
+        Poll::Ready(match ready!(self.channel().poll_next(lw)?) {
             Some(message) => {
                 match message.message {
                     ClientMessageKind::Request(request) => {
-                        self.handle_request(cx, message.trace_context, request)?;
+                        self.handle_request(lw, message.trace_context, request)?;
                     }
                     ClientMessageKind::Cancel { request_id } => {
                         self.cancel_request(&message.trace_context, request_id);
@@ -349,23 +352,23 @@ where
     }
 
     fn pump_write(
-        self: &mut PinMut<Self>,
-        cx: &mut task::Context,
+        self: &mut Pin<Self>,
+        lw: &LocalWaker,
         read_half_closed: bool,
     ) -> Poll<Option<io::Result<()>>> {
-        match self.poll_next_response(cx)? {
+        match self.poll_next_response(lw)? {
             Poll::Ready(Some((_, response))) => {
                 self.channel().start_send(response)?;
                 Poll::Ready(Some(Ok(())))
             }
             Poll::Ready(None) => {
                 // Shutdown can't be done before we finish pumping out remaining responses.
-                ready!(self.channel().poll_flush(cx)?);
+                ready!(self.channel().poll_flush(lw)?);
                 Poll::Ready(None)
             }
             Poll::Pending => {
                 // No more requests to process, so flush any requests buffered in the transport.
-                ready!(self.channel().poll_flush(cx)?);
+                ready!(self.channel().poll_flush(lw)?);
 
                 // Being here means there are no staged requests and all written responses are
                 // fully flushed. So, if the read half is closed and there are no in-flight
@@ -380,17 +383,17 @@ where
     }
 
     fn poll_next_response(
-        self: &mut PinMut<Self>,
-        cx: &mut task::Context,
+        self: &mut Pin<Self>,
+        lw: &LocalWaker,
     ) -> Poll<Option<io::Result<(Context, Response<Resp>)>>> {
         // Ensure there's room to write a response.
-        while let Poll::Pending = self.channel().poll_ready(cx)? {
-            ready!(self.channel().poll_flush(cx)?);
+        while let Poll::Pending = self.channel().poll_ready(lw)? {
+            ready!(self.channel().poll_flush(lw)?);
         }
 
         let peer = self.channel().client_addr;
 
-        match ready!(self.pending_responses().poll_next(cx)) {
+        match ready!(self.pending_responses().poll_next(lw)) {
             Some((ctx, response)) => {
                 if let Some(_) = self.in_flight_requests().remove(&response.request_id) {
                     self.in_flight_requests().compact(0.1);
@@ -412,8 +415,8 @@ where
     }
 
     fn handle_request(
-        self: &mut PinMut<Self>,
-        cx: &mut task::Context,
+        self: &mut Pin<Self>,
+        lw: &LocalWaker,
         trace_context: trace::Context,
         request: Request<Req>,
     ) -> io::Result<()> {
@@ -473,7 +476,7 @@ where
             },
         );
         let (abortable_response, abort_handle) = abortable(response);
-        cx.spawner()
+        lw.spawner()
             .spawn(abortable_response.map(|_| ()))
             .map_err(|e| {
                 io::Error::new(
@@ -488,7 +491,7 @@ where
         Ok(())
     }
 
-    fn cancel_request(self: &mut PinMut<Self>, trace_context: &trace::Context, request_id: u64) {
+    fn cancel_request(self: &mut Pin<Self>, trace_context: &trace::Context, request_id: u64) {
         // It's possible the request was already completed, so it's fine
         // if this is None.
         if let Some(cancel_handle) = self.in_flight_requests().remove(&request_id) {
@@ -523,11 +526,11 @@ where
 {
     type Output = io::Result<()>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+    fn poll(mut self: Pin<Self>, lw: &LocalWaker) -> Poll<io::Result<()>> {
         trace!("[{}] ClientHandler::poll", self.channel.client_addr);
         loop {
-            let read = self.pump_read(cx)?;
-            match (read, self.pump_write(cx, read == Poll::Ready(None))?) {
+            let read = self.pump_read(lw)?;
+            match (read, self.pump_write(lw, read == Poll::Ready(None))?) {
                 (Poll::Ready(None), Poll::Ready(None)) => {
                     info!("[{}] Client disconnected.", self.channel.client_addr);
                     return Poll::Ready(Ok(()));

--- a/rpc/src/util/deadline_compat.rs
+++ b/rpc/src/util/deadline_compat.rs
@@ -1,10 +1,12 @@
 use futures::{
     compat::{Compat, Future01CompatExt},
     prelude::*,
-    ready, task,
+    ready,
+    Poll
 };
 use pin_utils::unsafe_pinned;
-use std::pin::PinMut;
+use std::pin::Pin;
+use std::task::LocalWaker;
 use std::time::Instant;
 use tokio_timer::{timeout, Delay};
 
@@ -12,12 +14,12 @@ use tokio_timer::{timeout, Delay};
 #[derive(Debug)]
 pub struct Deadline<T> {
     future: T,
-    delay: Compat<Delay, ()>,
+    delay: Compat<Delay>,
 }
 
 impl<T> Deadline<T> {
     unsafe_pinned!(future: T);
-    unsafe_pinned!(delay: Compat<Delay, ()>);
+    unsafe_pinned!(delay: Compat<Delay>);
 
     /// Create a new `Deadline` that completes when `future` completes or when
     /// `deadline` is reached.
@@ -43,16 +45,16 @@ where
 {
     type Output = Result<T::Ok, timeout::Error<T::Error>>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<Self>, lw: &LocalWaker) -> Poll<Self::Output> {
         // First, try polling the future
-        match self.future().try_poll(cx) {
+        match self.future().try_poll(lw) {
             Poll::Ready(Ok(v)) => return Poll::Ready(Ok(v)),
             Poll::Pending => {}
             Poll::Ready(Err(e)) => return Poll::Ready(Err(timeout::Error::inner(e))),
         }
 
         // Now check the timer
-        match ready!(self.delay().poll_unpin(cx)) {
+        match ready!(self.delay().poll_unpin(lw)) {
             Ok(_) => Poll::Ready(Err(timeout::Error::elapsed())),
             Err(e) => Poll::Ready(Err(timeout::Error::timer(e))),
         }

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -28,11 +28,11 @@ tarpc-plugins = { path = "../plugins", version = "0.4.0" }
 rpc = { path = "../rpc" }
 
 [target.'cfg(not(test))'.dependencies]
-futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs" }
+futures-preview = { version = "0.3.0-alpha.6" }
 
 [dev-dependencies]
 humantime = "1.0"
-futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs", features = ["compat", "tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
 bincode-transport = { path = "../bincode-transport" }
 env_logger = "0.5"
 tokio = "0.1"

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -28,11 +28,11 @@ tarpc-plugins = { path = "../plugins", version = "0.4.0" }
 rpc = { path = "../rpc" }
 
 [target.'cfg(not(test))'.dependencies]
-futures-preview = { version = "0.3.0-alpha.6" }
+futures-preview = { version = "0.3.0-alpha.7" }
 
 [dev-dependencies]
 humantime = "1.0"
-futures-preview = { version = "0.3.0-alpha.6", features = ["compat", "tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.7", features = ["compat", "tokio-compat"] }
 bincode-transport = { path = "../bincode-transport" }
 env_logger = "0.5"
 tokio = "0.1"


### PR DESCRIPTION
Hello, I'm trying to get this branch to compile so that I can use features that aren't available in the released version of tarpc. Specifically creating clients from inside server handlers, so that when a new client calls an RPC, we can open a connection in the other direction. Which couldn't work because the old `tokio_core::Handle` is `!Send`.

Anyways, this PR tries to update your PR for the newest nightly and futures-preview version 0.3.0-alpha.7. The biggest problems are that polling and spawning got separated out from `std::task::Context`, so now polling is handled by `std::task::LocalWaker` and spawning by an reference to an executor that implements `futures::task::Spawn`. If I understand correctly there also isn't a default executor, so the user will need to make one and pass it in to the `transport`and `new_stub`. Most of the diffs are just substituting `LocalWaker` in for `Context`, which appears to be the idiomatic thing to do. We'll have to add back in a `spawner` to the code that needs to spawn new futures onto the executor.

I'm running into problems with the new `Pin`ning API, so I'm submitting this as a WIP PR, hoping you have to the time to help. It seems like the new API expects `Pin` to wrap a pointer or reference, so I switched from using `&mut Pin<Self>` to `Pin<&mut Self>`, which seemed to work better for most of the errors I was getting in rpc/src/server/mod.rs `ClientHandler::handle_request` L422, except for one, where the compiler error says that now `ClientHandler` doesn't implement `futures::sink::Sink`. It could have something to do with the `Pin<&mut Channel>`, but `Sink` is supposed to implement itself for `Pin<&'a mut S> where S: Sink + ?Szed` per the 0.3.0-alpha.7 documentation, which makes me think that `Channel` isn't `Sink` anymore. 

```
error[E0599]: no method named `start_send` found for type `std::pin::Pin<&mut server::Channel<Req, Resp, T>>` in the current scope
   --> rpc/src/server/mod.rs:446:28                                                           
    |                                                                                         
446 |             self.channel().start_send(Response {                                        
    |                            ^^^^^^^^^^                                                   
    |                                                                                         
    = help: items from traits can only be used if the trait is implemented and in scope       
    = note: the following traits define an item `start_send`, perhaps you need to implement one of them:
            candidate #1: `futures_sink::Sink`                                                
            candidate #2: `futures::sink::Sink`                                               
```

Any help you could offer would be much appreciated.