### PR TITLE
Add anymap to context

### DIFF
--- a/example-service/src/client.rs
+++ b/example-service/src/client.rs
@@ -10,6 +10,7 @@ use std::{net::SocketAddr, time::Duration};
 use tarpc::{client, context, tokio_serde::formats::Json};
 use tokio::time::sleep;
 use tracing::Instrument;
+use tarpc::context::ClientContext;
 
 #[derive(Parser)]
 struct Flags {
@@ -34,8 +35,8 @@ async fn main() -> anyhow::Result<()> {
     let client = WorldClient::new(client::Config::default(), transport.await?).spawn();
 
     let hello = async move {
-        let mut context = context::current();
-        let mut context2 = context::current();
+        let mut context = ClientContext::current();
+        let mut context2 = ClientContext::current();
 
         // Send the request twice, just to be safe! ;)
         tokio::select! {

--- a/example-service/src/client.rs
+++ b/example-service/src/client.rs
@@ -34,10 +34,13 @@ async fn main() -> anyhow::Result<()> {
     let client = WorldClient::new(client::Config::default(), transport.await?).spawn();
 
     let hello = async move {
+        let mut context = context::current();
+        let mut context2 = context::current();
+
         // Send the request twice, just to be safe! ;)
         tokio::select! {
-            hello1 = client.hello(context::current(), format!("{}1", flags.name)) => { hello1 }
-            hello2 = client.hello(context::current(), format!("{}2", flags.name)) => { hello2 }
+            hello1 = client.hello(&mut context, format!("{}1", flags.name)) => { hello1 }
+            hello2 = client.hello(&mut context2, format!("{}2", flags.name)) => { hello2 }
         }
     }
     .instrument(tracing::info_span!("Two Hellos"))

--- a/example-service/src/server.rs
+++ b/example-service/src/server.rs
@@ -35,7 +35,7 @@ struct Flags {
 struct HelloServer(SocketAddr);
 
 impl World for HelloServer {
-    async fn hello(self, _: &mut context::Context, name: String) -> String {
+    async fn hello(self, _: &mut context::ServerContext, name: String) -> String {
         let sleep_time =
             Duration::from_millis(Uniform::new_inclusive(1, 10).sample(&mut thread_rng()));
         time::sleep(sleep_time).await;

--- a/example-service/src/server.rs
+++ b/example-service/src/server.rs
@@ -35,7 +35,7 @@ struct Flags {
 struct HelloServer(SocketAddr);
 
 impl World for HelloServer {
-    async fn hello(self, _: context::Context, name: String) -> String {
+    async fn hello(self, _: &mut context::Context, name: String) -> String {
         let sleep_time =
             Duration::from_millis(Uniform::new_inclusive(1, 10).sample(&mut thread_rng()));
         time::sleep(sleep_time).await;

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -375,7 +375,7 @@ fn collect_cfg_attrs(rpcs: &[RpcMethod]) -> Vec<Vec<&Attribute>> {
 /// # Example
 ///
 /// ```no_run
-/// use tarpc::{client, transport, service, server::{self, Channel}, context::Context};
+/// use tarpc::{client, transport, service, server::{self, Channel}, context::ServerContext};
 ///
 /// #[service]
 /// pub trait Calculator {
@@ -401,7 +401,7 @@ fn collect_cfg_attrs(rpcs: &[RpcMethod]) -> Vec<Vec<&Attribute>> {
 /// #[derive(Clone)]
 /// struct CalculatorServer;
 /// impl Calculator for CalculatorServer {
-///     async fn add(self, context: &mut Context, a: i32, b: i32) -> i32 {
+///     async fn add(self, context: &mut ServerContext, a: i32, b: i32) -> i32 {
 ///         a + b
 ///     }
 /// }
@@ -558,7 +558,7 @@ impl ServiceGenerator<'_> {
                  )| {
                     quote! {
                         #( #attrs )*
-                        async fn #ident(self, context: &mut ::tarpc::context::Context, #( #args ),*) -> #output;
+                        async fn #ident(self, context: &mut ::tarpc::context::ServerContext, #( #args ),*) -> #output;
                     }
                 },
             );
@@ -622,7 +622,7 @@ impl ServiceGenerator<'_> {
                 type Resp = #response_ident;
 
 
-                async fn serve(self, ctx: &mut ::tarpc::context::Context, req: #request_ident)
+                async fn serve(self, ctx: &mut ::tarpc::context::ServerContext, req: #request_ident)
                     -> ::core::result::Result<#response_ident, ::tarpc::ServerError> {
                     match req {
                         #(
@@ -786,7 +786,7 @@ impl ServiceGenerator<'_> {
                 #(
                     #[allow(unused)]
                     #( #method_attrs )*
-                    #vis fn #method_idents<'a>(&'a self, ctx: &'a mut ::tarpc::context::Context, #( #args ),*)
+                    #vis fn #method_idents<'a>(&'a self, ctx: &'a mut ::tarpc::context::ClientContext, #( #args ),*)
                         -> impl ::core::future::Future<Output = ::core::result::Result<#return_types, ::tarpc::client::RpcError>> + '_ {
                         let request = #request_ident::#camel_case_idents { #( #arg_pats ),* };
                         let resp = self.0.call(ctx, request);

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -401,7 +401,7 @@ fn collect_cfg_attrs(rpcs: &[RpcMethod]) -> Vec<Vec<&Attribute>> {
 /// #[derive(Clone)]
 /// struct CalculatorServer;
 /// impl Calculator for CalculatorServer {
-///     async fn add(self, context: Context, a: i32, b: i32) -> i32 {
+///     async fn add(self, context: &mut Context, a: i32, b: i32) -> i32 {
 ///         a + b
 ///     }
 /// }
@@ -558,7 +558,7 @@ impl ServiceGenerator<'_> {
                  )| {
                     quote! {
                         #( #attrs )*
-                        async fn #ident(self, context: ::tarpc::context::Context, #( #args ),*) -> #output;
+                        async fn #ident(self, context: &mut ::tarpc::context::Context, #( #args ),*) -> #output;
                     }
                 },
             );
@@ -622,7 +622,7 @@ impl ServiceGenerator<'_> {
                 type Resp = #response_ident;
 
 
-                async fn serve(self, ctx: ::tarpc::context::Context, req: #request_ident)
+                async fn serve(self, ctx: &mut ::tarpc::context::Context, req: #request_ident)
                     -> ::core::result::Result<#response_ident, ::tarpc::ServerError> {
                     match req {
                         #(
@@ -786,7 +786,7 @@ impl ServiceGenerator<'_> {
                 #(
                     #[allow(unused)]
                     #( #method_attrs )*
-                    #vis fn #method_idents(&self, ctx: ::tarpc::context::Context, #( #args ),*)
+                    #vis fn #method_idents<'a>(&'a self, ctx: &'a mut ::tarpc::context::Context, #( #args ),*)
                         -> impl ::core::future::Future<Output = ::core::result::Result<#return_types, ::tarpc::client::RpcError>> + '_ {
                         let request = #request_ident::#camel_case_idents { #( #arg_pats ),* };
                         let resp = self.0.call(ctx, request);

--- a/plugins/tests/service.rs
+++ b/plugins/tests/service.rs
@@ -12,15 +12,15 @@ fn att_service_trait() {
     }
 
     impl Foo for () {
-        async fn two_part(self, _: context::Context, s: String, i: i32) -> (String, i32) {
+        async fn two_part(self, _: &mut context::Context, s: String, i: i32) -> (String, i32) {
             (s, i)
         }
 
-        async fn bar(self, _: context::Context, s: String) -> String {
+        async fn bar(self, _: &mut context::Context, s: String) -> String {
             s
         }
 
-        async fn baz(self, _: context::Context) {}
+        async fn baz(self, _: &mut context::Context) {}
     }
 }
 
@@ -39,18 +39,18 @@ fn raw_idents() {
     impl r#trait for () {
         async fn r#await(
             self,
-            _: context::Context,
+            _: &mut context::Context,
             r#struct: r#yield,
             r#enum: i32,
         ) -> (r#yield, i32) {
             (r#struct, r#enum)
         }
 
-        async fn r#fn(self, _: context::Context, r#impl: r#yield) -> r#yield {
+        async fn r#fn(self, _: &mut context::Context, r#impl: r#yield) -> r#yield {
             r#impl
         }
 
-        async fn r#async(self, _: context::Context) {}
+        async fn r#async(self, _: &mut context::Context) {}
     }
 }
 
@@ -64,7 +64,7 @@ fn service_with_cfg_rpc() {
     }
 
     impl Foo for () {
-        async fn foo(self, _: context::Context) {}
+        async fn foo(self, _: &mut context::Context) {}
     }
 }
 

--- a/plugins/tests/service.rs
+++ b/plugins/tests/service.rs
@@ -12,15 +12,15 @@ fn att_service_trait() {
     }
 
     impl Foo for () {
-        async fn two_part(self, _: &mut context::Context, s: String, i: i32) -> (String, i32) {
+        async fn two_part(self, _: &mut context::ServerContext, s: String, i: i32) -> (String, i32) {
             (s, i)
         }
 
-        async fn bar(self, _: &mut context::Context, s: String) -> String {
+        async fn bar(self, _: &mut context::ServerContext, s: String) -> String {
             s
         }
 
-        async fn baz(self, _: &mut context::Context) {}
+        async fn baz(self, _: &mut context::ServerContext) {}
     }
 }
 
@@ -39,18 +39,18 @@ fn raw_idents() {
     impl r#trait for () {
         async fn r#await(
             self,
-            _: &mut context::Context,
+            _: &mut context::ServerContext,
             r#struct: r#yield,
             r#enum: i32,
         ) -> (r#yield, i32) {
             (r#struct, r#enum)
         }
 
-        async fn r#fn(self, _: &mut context::Context, r#impl: r#yield) -> r#yield {
+        async fn r#fn(self, _: &mut context::ServerContext, r#impl: r#yield) -> r#yield {
             r#impl
         }
 
-        async fn r#async(self, _: &mut context::Context) {}
+        async fn r#async(self, _: &mut context::ServerContext) {}
     }
 }
 
@@ -64,7 +64,7 @@ fn service_with_cfg_rpc() {
     }
 
     impl Foo for () {
-        async fn foo(self, _: &mut context::Context) {}
+        async fn foo(self, _: &mut context::ServerContext) {}
     }
 }
 

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -61,6 +61,7 @@ tracing = { version = "0.1", default-features = false, features = [
 tracing-opentelemetry = { version = "0.31.0", default-features = false }
 opentelemetry = { version = "0.30.0", default-features = false }
 opentelemetry-semantic-conventions = "0.30.0"
+anymap3 = "1.0.1"
 
 [dev-dependencies]
 assert_matches = "1.4"

--- a/tarpc/examples/compression.rs
+++ b/tarpc/examples/compression.rs
@@ -108,7 +108,7 @@ pub trait World {
 struct HelloServer;
 
 impl World for HelloServer {
-    async fn hello(self, _: context::Context, name: String) -> String {
+    async fn hello(self, _: &mut context::Context, name: String) -> String {
         format!("Hey, {name}!")
     }
 }
@@ -134,7 +134,7 @@ async fn main() -> anyhow::Result<()> {
 
     println!(
         "{}",
-        client.hello(context::current(), "friend".into()).await?
+        client.hello(&mut context::current(), "friend".into()).await?
     );
     Ok(())
 }

--- a/tarpc/examples/compression.rs
+++ b/tarpc/examples/compression.rs
@@ -108,7 +108,7 @@ pub trait World {
 struct HelloServer;
 
 impl World for HelloServer {
-    async fn hello(self, _: &mut context::Context, name: String) -> String {
+    async fn hello(self, _: &mut context::ServerContext, name: String) -> String {
         format!("Hey, {name}!")
     }
 }
@@ -134,7 +134,7 @@ async fn main() -> anyhow::Result<()> {
 
     println!(
         "{}",
-        client.hello(&mut context::current(), "friend".into()).await?
+        client.hello(&mut context::ClientContext::current(), "friend".into()).await?
     );
     Ok(())
 }

--- a/tarpc/examples/custom_transport.rs
+++ b/tarpc/examples/custom_transport.rs
@@ -21,7 +21,7 @@ pub trait PingService {
 struct Service;
 
 impl PingService for Service {
-    async fn ping(self, _: Context) {}
+    async fn ping(self, _: &mut Context) {}
 }
 
 #[tokio::main]
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
     let transport = transport::new(codec_builder.new_framed(conn), Bincode::default());
     PingServiceClient::new(Default::default(), transport)
         .spawn()
-        .ping(tarpc::context::current())
+        .ping(&mut tarpc::context::current())
         .await?;
 
     Ok(())

--- a/tarpc/examples/custom_transport.rs
+++ b/tarpc/examples/custom_transport.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 use futures::prelude::*;
-use tarpc::context::Context;
+use tarpc::context::{ClientContext, ServerContext};
 use tarpc::serde_transport as transport;
 use tarpc::server::{BaseChannel, Channel};
 use tarpc::tokio_serde::formats::Bincode;
@@ -21,7 +21,7 @@ pub trait PingService {
 struct Service;
 
 impl PingService for Service {
-    async fn ping(self, _: &mut Context) {}
+    async fn ping(self, _: &mut ServerContext) {}
 }
 
 #[tokio::main]
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
     let transport = transport::new(codec_builder.new_framed(conn), Bincode::default());
     PingServiceClient::new(Default::default(), transport)
         .spawn()
-        .ping(&mut tarpc::context::current())
+        .ping(&mut ClientContext::current())
         .await?;
 
     Ok(())

--- a/tarpc/examples/pubsub.rs
+++ b/tarpc/examples/pubsub.rs
@@ -80,11 +80,11 @@ struct Subscriber {
 }
 
 impl subscriber::Subscriber for Subscriber {
-    async fn topics(self, _: context::Context) -> Vec<String> {
+    async fn topics(self, _: &mut context::Context) -> Vec<String> {
         self.topics.clone()
     }
 
-    async fn receive(self, _: context::Context, topic: String, message: String) {
+    async fn receive(self, _: &mut context::Context, topic: String, message: String) {
         info!(local_addr = %self.local_addr, %topic, %message, "ReceivedMessage")
     }
 }
@@ -210,7 +210,7 @@ impl Publisher {
         subscriber: subscriber::SubscriberClient,
     ) {
         // Populate the topics
-        if let Ok(topics) = subscriber.topics(context::current()).await {
+        if let Ok(topics) = subscriber.topics(&mut context::current()).await {
             self.clients.lock().unwrap().insert(
                 subscriber_addr,
                 Subscription {
@@ -263,15 +263,20 @@ impl Publisher {
 }
 
 impl publisher::Publisher for Publisher {
-    async fn publish(self, _: context::Context, topic: String, message: String) {
+    async fn publish(self, _: &mut context::Context, topic: String, message: String) {
         info!("received message to publish.");
         let mut subscribers = match self.subscriptions.read().unwrap().get(&topic) {
             None => return,
             Some(subscriptions) => subscriptions.clone(),
         };
         let mut publications = Vec::new();
+
+
         for client in subscribers.values_mut() {
-            publications.push(client.receive(context::current(), topic.clone(), message.clone()));
+            publications.push(async {
+                let mut context = context::current();
+                client.receive(&mut context, topic.clone(), message.clone()).await
+            });
         }
         // Ignore failing subscribers. In a real pubsub, you'd want to continually retry until
         // subscribers ack. Of course, a lot would be different in a real pubsub :)
@@ -342,26 +347,26 @@ async fn main() -> anyhow::Result<()> {
     .spawn();
 
     publisher
-        .publish(context::current(), "calculus".into(), "sqrt(2)".into())
+        .publish(&mut context::current(), "calculus".into(), "sqrt(2)".into())
         .await?;
 
     publisher
         .publish(
-            context::current(),
+            &mut context::current(),
             "cool shorts".into(),
             "hello to all".into(),
         )
         .await?;
 
     publisher
-        .publish(context::current(), "history".into(), "napoleon".to_string())
+        .publish(&mut context::current(), "history".into(), "napoleon".to_string())
         .await?;
 
     drop(_subscriber0);
 
     publisher
         .publish(
-            context::current(),
+            &mut context::current(),
             "cool shorts".into(),
             "hello to who?".into(),
         )

--- a/tarpc/examples/pubsub.rs
+++ b/tarpc/examples/pubsub.rs
@@ -80,11 +80,11 @@ struct Subscriber {
 }
 
 impl subscriber::Subscriber for Subscriber {
-    async fn topics(self, _: &mut context::Context) -> Vec<String> {
+    async fn topics(self, _: &mut context::ServerContext) -> Vec<String> {
         self.topics.clone()
     }
 
-    async fn receive(self, _: &mut context::Context, topic: String, message: String) {
+    async fn receive(self, _: &mut context::ServerContext, topic: String, message: String) {
         info!(local_addr = %self.local_addr, %topic, %message, "ReceivedMessage")
     }
 }
@@ -210,7 +210,7 @@ impl Publisher {
         subscriber: subscriber::SubscriberClient,
     ) {
         // Populate the topics
-        if let Ok(topics) = subscriber.topics(&mut context::current()).await {
+        if let Ok(topics) = subscriber.topics(&mut context::ClientContext::current()).await {
             self.clients.lock().unwrap().insert(
                 subscriber_addr,
                 Subscription {
@@ -263,7 +263,7 @@ impl Publisher {
 }
 
 impl publisher::Publisher for Publisher {
-    async fn publish(self, _: &mut context::Context, topic: String, message: String) {
+    async fn publish(self, _: &mut context::ServerContext, topic: String, message: String) {
         info!("received message to publish.");
         let mut subscribers = match self.subscriptions.read().unwrap().get(&topic) {
             None => return,
@@ -274,8 +274,7 @@ impl publisher::Publisher for Publisher {
 
         for client in subscribers.values_mut() {
             publications.push(async {
-                let mut context = context::current();
-                client.receive(&mut context, topic.clone(), message.clone()).await
+                client.receive(&mut context::ClientContext::current(), topic.clone(), message.clone()).await
             });
         }
         // Ignore failing subscribers. In a real pubsub, you'd want to continually retry until
@@ -347,26 +346,26 @@ async fn main() -> anyhow::Result<()> {
     .spawn();
 
     publisher
-        .publish(&mut context::current(), "calculus".into(), "sqrt(2)".into())
+        .publish(&mut context::ClientContext::current(), "calculus".into(), "sqrt(2)".into())
         .await?;
 
     publisher
         .publish(
-            &mut context::current(),
+            &mut context::ClientContext::current(),
             "cool shorts".into(),
             "hello to all".into(),
         )
         .await?;
 
     publisher
-        .publish(&mut context::current(), "history".into(), "napoleon".to_string())
+        .publish(&mut context::ClientContext::current(), "history".into(), "napoleon".to_string())
         .await?;
 
     drop(_subscriber0);
 
     publisher
         .publish(
-            &mut context::current(),
+            &mut context::ClientContext::current(),
             "cool shorts".into(),
             "hello to who?".into(),
         )

--- a/tarpc/examples/readme.rs
+++ b/tarpc/examples/readme.rs
@@ -23,7 +23,7 @@ pub trait World {
 struct HelloServer;
 
 impl World for HelloServer {
-    async fn hello(self, _: context::Context, name: String) -> String {
+    async fn hello(self, _: &mut context::Context, name: String) -> String {
         format!("Hello, {name}!")
     }
 }
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
     // The client has an RPC method for each RPC defined in the annotated trait. It takes the same
     // args as defined, with the addition of a Context, which is always the first arg. The Context
     // specifies a deadline and trace information which can be helpful in debugging requests.
-    let hello = client.hello(context::current(), "Stim".to_string()).await?;
+    let hello = client.hello(&mut context::current(), "Stim".to_string()).await?;
 
     println!("{hello}");
 

--- a/tarpc/examples/readme.rs
+++ b/tarpc/examples/readme.rs
@@ -23,7 +23,7 @@ pub trait World {
 struct HelloServer;
 
 impl World for HelloServer {
-    async fn hello(self, _: &mut context::Context, name: String) -> String {
+    async fn hello(self, _: &mut context::ServerContext, name: String) -> String {
         format!("Hello, {name}!")
     }
 }
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
     // The client has an RPC method for each RPC defined in the annotated trait. It takes the same
     // args as defined, with the addition of a Context, which is always the first arg. The Context
     // specifies a deadline and trace information which can be helpful in debugging requests.
-    let hello = client.hello(&mut context::current(), "Stim".to_string()).await?;
+    let hello = client.hello(&mut context::ClientContext::current(), "Stim".to_string()).await?;
 
     println!("{hello}");
 

--- a/tarpc/examples/tls_over_tcp.rs
+++ b/tarpc/examples/tls_over_tcp.rs
@@ -18,7 +18,7 @@ use tokio_rustls::rustls::{
 };
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
-use tarpc::context::Context;
+use tarpc::context::{ClientContext, ServerContext};
 use tarpc::serde_transport as transport;
 use tarpc::server::{BaseChannel, Channel};
 use tarpc::tokio_serde::formats::Bincode;
@@ -33,7 +33,7 @@ pub trait PingService {
 struct Service;
 
 impl PingService for Service {
-    async fn ping(self, _: &mut Context) -> String {
+    async fn ping(self, _: &mut ServerContext) -> String {
         "🔒".to_owned()
     }
 }
@@ -146,7 +146,7 @@ async fn main() -> anyhow::Result<()> {
     let transport = transport::new(codec_builder.new_framed(stream), Bincode::default());
     let answer = PingServiceClient::new(Default::default(), transport)
         .spawn()
-        .ping(&mut tarpc::context::current())
+        .ping(&mut ClientContext::current())
         .await?;
 
     println!("ping answer: {answer}");

--- a/tarpc/examples/tls_over_tcp.rs
+++ b/tarpc/examples/tls_over_tcp.rs
@@ -33,7 +33,7 @@ pub trait PingService {
 struct Service;
 
 impl PingService for Service {
-    async fn ping(self, _: Context) -> String {
+    async fn ping(self, _: &mut Context) -> String {
         "🔒".to_owned()
     }
 }
@@ -146,7 +146,7 @@ async fn main() -> anyhow::Result<()> {
     let transport = transport::new(codec_builder.new_framed(stream), Bincode::default());
     let answer = PingServiceClient::new(Default::default(), transport)
         .spawn()
-        .ping(tarpc::context::current())
+        .ping(&mut tarpc::context::current())
         .await?;
 
     println!("ping answer: {answer}");

--- a/tarpc/examples/tracing.rs
+++ b/tarpc/examples/tracing.rs
@@ -56,7 +56,7 @@ pub mod double {
 struct AddServer;
 
 impl AddService for AddServer {
-    async fn add(self, _: context::Context, x: i32, y: i32) -> i32 {
+    async fn add(self, _: &mut context::Context, x: i32, y: i32) -> i32 {
         x + y
     }
 }
@@ -70,9 +70,9 @@ impl<Stub> DoubleService for DoubleServer<Stub>
 where
     Stub: AddStub + Clone + Send + Sync + 'static,
 {
-    async fn double(self, _: context::Context, x: i32) -> Result<i32, String> {
+    async fn double(self, _: &mut context::Context, x: i32) -> Result<i32, String> {
         self.add_client
-            .add(context::current(), x, x)
+            .add(&mut context::current(), x, x)
             .await
             .map_err(|e| e.to_string())
     }
@@ -193,9 +193,9 @@ async fn main() -> anyhow::Result<()> {
     let double_client =
         double::DoubleClient::new(client::Config::default(), to_double_server).spawn();
 
-    let ctx = context::current();
+    let mut ctx = context::current();
     for _ in 1..=5 {
-        tracing::info!("{:?}", double_client.double(ctx, 1).await?);
+        tracing::info!("{:?}", double_client.double(&mut ctx, 1).await?);
     }
 
     tracer_provider.shutdown()?;

--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -128,7 +128,7 @@ where
             otel.kind = "client",
             otel.name = %request.name())
         )]
-    pub async fn call(&self, mut ctx: context::Context, request: Req) -> Result<Resp, RpcError> {
+    pub async fn call(&self, ctx: &mut context::Context, request: Req) -> Result<Resp, RpcError> {
         let span = Span::current();
         ctx.trace_context = trace::Context::try_from(&span).unwrap_or_else(|_| {
             tracing::trace!(
@@ -153,7 +153,10 @@ where
         };
         self.to_dispatch
             .send(DispatchRequest {
-                ctx,
+                ctx: context::Context {
+                    deadline: ctx.deadline,
+                    trace_context: ctx.trace_context.clone(),
+                },
                 span,
                 request_id,
                 request,
@@ -881,7 +884,7 @@ mod tests {
         let (dispatch, channel, _server_channel) = set_up();
         drop(dispatch);
         // error on send
-        let resp = channel.call(current(), "hi".to_string()).await;
+        let resp = channel.call(&mut current(), "hi".to_string()).await;
         assert_matches!(resp, Err(RpcError::Shutdown));
     }
 

--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -128,7 +128,7 @@ where
             otel.kind = "client",
             otel.name = %request.name())
         )]
-    pub async fn call(&self, ctx: &mut context::Context, request: Req) -> Result<Resp, RpcError> {
+    pub async fn call(&self, ctx: &mut context::SharedContext, request: Req) -> Result<Resp, RpcError> {
         let span = Span::current();
         ctx.trace_context = trace::Context::try_from(&span).unwrap_or_else(|_| {
             tracing::trace!(
@@ -153,10 +153,7 @@ where
         };
         self.to_dispatch
             .send(DispatchRequest {
-                ctx: context::Context {
-                    deadline: ctx.deadline,
-                    trace_context: ctx.trace_context.clone(),
-                },
+                ctx: ctx.clone(),
                 span,
                 request_id,
                 request,
@@ -460,7 +457,7 @@ where
     fn poll_next_cancellation(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<(context::Context, Span, u64), ChannelError<C::Error>>>> {
+    ) -> Poll<Option<Result<(context::ClientContext, Span, u64), ChannelError<C::Error>>>> {
         ready!(self.ensure_writeable(cx)?);
 
         loop {
@@ -516,13 +513,15 @@ where
         let request = ClientMessage::Request(Request {
             id: request_id,
             message: request,
-            context: context::Context {
-                deadline: ctx.deadline,
-                trace_context: ctx.trace_context,
-            },
+            context: ctx.clone(),
         });
+
+        //TODO: Feels like we could avoid either saving the request context in insert_request
+        // or submitting the context in start_request.
+        let full_context = context::ClientContext::new(ctx);
+
         self.in_flight_requests()
-            .insert_request(request_id, ctx, span.clone(), response_completion)
+            .insert_request(request_id, full_context, span.clone(), response_completion)
             .expect("Request IDs should be unique");
         match self.start_send(request) {
             Ok(()) => tracing::debug!("SendRequest"),
@@ -672,7 +671,7 @@ where
 /// the lifecycle of the request.
 #[derive(Debug)]
 struct DispatchRequest<Req, Resp> {
-    pub ctx: context::Context,
+    pub ctx: context::SharedContext,
     pub span: Span,
     pub request_id: u64,
     pub request: Req,
@@ -687,7 +686,6 @@ mod tests {
     use crate::{
         ChannelError, ClientMessage, Response,
         client::{Config, in_flight_requests::InFlightRequests},
-        context::{self, current},
         transport::{self, channel::UnboundedChannel},
     };
     use assert_matches::assert_matches;
@@ -708,6 +706,7 @@ mod tests {
         oneshot,
     };
     use tracing::Span;
+    use crate::context::{ClientContext, SharedContext};
 
     #[tokio::test]
     async fn response_completes_request_future() {
@@ -717,7 +716,7 @@ mod tests {
 
         dispatch
             .in_flight_requests
-            .insert_request(0, context::current(), Span::current(), tx)
+            .insert_request(0, ClientContext::current(), Span::current(), tx)
             .unwrap();
         server_channel
             .send(Response {
@@ -884,7 +883,7 @@ mod tests {
         let (dispatch, channel, _server_channel) = set_up();
         drop(dispatch);
         // error on send
-        let resp = channel.call(&mut current(), "hi".to_string()).await;
+        let resp = channel.call(&mut ClientContext::current(), "hi".to_string()).await;
         assert_matches!(resp, Err(RpcError::Shutdown));
     }
 
@@ -1094,7 +1093,7 @@ mod tests {
             let request_id =
                 u64::try_from(channel.next_request_id.fetch_add(1, Ordering::Relaxed)).unwrap();
             let request = DispatchRequest {
-                ctx: context::current(),
+                ctx: SharedContext::current(),
                 span: Span::current(),
                 request_id,
                 request: request.to_string(),
@@ -1119,7 +1118,7 @@ mod tests {
         let request_id =
             u64::try_from(channel.next_request_id.fetch_add(1, Ordering::Relaxed)).unwrap();
         let request = DispatchRequest {
-            ctx: context::current(),
+            ctx: SharedContext::current(),
             span: Span::current(),
             request_id,
             request: request.to_string(),

--- a/tarpc/src/client/in_flight_requests.rs
+++ b/tarpc/src/client/in_flight_requests.rs
@@ -29,7 +29,7 @@ impl<Resp> Default for InFlightRequests<Resp> {
 
 #[derive(Debug)]
 struct RequestData<Res> {
-    ctx: context::Context,
+    ctx: context::ClientContext,
     span: Span,
     response_completion: oneshot::Sender<Res>,
     /// The key to remove the timer for the request's deadline.
@@ -56,7 +56,7 @@ impl<Res> InFlightRequests<Res> {
     pub fn insert_request(
         &mut self,
         request_id: u64,
-        ctx: context::Context,
+        ctx: context::ClientContext,
         span: Span,
         response_completion: oneshot::Sender<Res>,
     ) -> Result<(), AlreadyExistsError> {
@@ -106,7 +106,7 @@ impl<Res> InFlightRequests<Res> {
 
     /// Cancels a request without completing (typically used when a request handle was dropped
     /// before the request completed).
-    pub fn cancel_request(&mut self, request_id: u64) -> Option<(context::Context, Span)> {
+    pub fn cancel_request(&mut self, request_id: u64) -> Option<(context::ClientContext, Span)> {
         if let Some(request_data) = self.request_data.remove(&request_id) {
             self.request_data.compact(0.1);
             self.deadlines.remove(&request_data.deadline_key);

--- a/tarpc/src/client/stub.rs
+++ b/tarpc/src/client/stub.rs
@@ -24,7 +24,7 @@ pub trait Stub {
     type Resp;
 
     /// Calls a remote service.
-    async fn call(&self, ctx: context::Context, request: Self::Req)
+    async fn call(&self, ctx: &mut context::Context, request: Self::Req)
     -> Result<Self::Resp, RpcError>;
 }
 
@@ -35,7 +35,7 @@ where
     type Req = Req;
     type Resp = Resp;
 
-    async fn call(&self, ctx: context::Context, request: Req) -> Result<Self::Resp, RpcError> {
+    async fn call(&self, ctx: &mut context::Context, request: Req) -> Result<Self::Resp, RpcError> {
         Self::call(self, ctx, request).await
     }
 }
@@ -46,7 +46,7 @@ where
 {
     type Req = S::Req;
     type Resp = S::Resp;
-    async fn call(&self, ctx: context::Context, req: Self::Req) -> Result<Self::Resp, RpcError> {
+    async fn call(&self, ctx: &mut context::Context, req: Self::Req) -> Result<Self::Resp, RpcError> {
         self.clone().serve(ctx, req).await.map_err(RpcError::Server)
     }
 }

--- a/tarpc/src/client/stub.rs
+++ b/tarpc/src/client/stub.rs
@@ -24,7 +24,7 @@ pub trait Stub {
     type Resp;
 
     /// Calls a remote service.
-    async fn call(&self, ctx: &mut context::Context, request: Self::Req)
+    async fn call(&self, ctx: &mut context::ClientContext, request: Self::Req)
     -> Result<Self::Resp, RpcError>;
 }
 
@@ -35,7 +35,7 @@ where
     type Req = Req;
     type Resp = Resp;
 
-    async fn call(&self, ctx: &mut context::Context, request: Req) -> Result<Self::Resp, RpcError> {
+    async fn call(&self, ctx: &mut context::ClientContext, request: Req) -> Result<Self::Resp, RpcError> {
         Self::call(self, ctx, request).await
     }
 }
@@ -46,7 +46,13 @@ where
 {
     type Req = S::Req;
     type Resp = S::Resp;
-    async fn call(&self, ctx: &mut context::Context, req: Self::Req) -> Result<Self::Resp, RpcError> {
-        self.clone().serve(ctx, req).await.map_err(RpcError::Server)
+    async fn call(&self, ctx: &mut context::ClientContext, req: Self::Req) -> Result<Self::Resp, RpcError> {
+        let mut server_ctx = context::ServerContext::new(ctx.shared_context.clone());
+
+        let res = self.clone().serve(&mut server_ctx, req).await.map_err(RpcError::Server);
+
+        ctx.shared_context = server_ctx.shared_context;
+
+        res
     }
 }

--- a/tarpc/src/client/stub/load_balance.rs
+++ b/tarpc/src/client/stub/load_balance.rs
@@ -20,7 +20,7 @@ mod round_robin {
 
         async fn call(
             &self,
-            ctx: &mut context::Context,
+            ctx: &mut context::ClientContext,
             request: Self::Req,
         ) -> Result<Stub::Resp, RpcError> {
             let next = self.stubs.next();
@@ -119,7 +119,7 @@ mod consistent_hash {
 
         async fn call(
             &self,
-            ctx: &mut context::Context,
+            ctx: &mut context::ClientContext,
             request: Self::Req,
         ) -> Result<Stub::Resp, RpcError> {
             let index = usize::try_from(self.hasher.hash_one(&request) % self.stubs_len).expect(
@@ -200,13 +200,13 @@ mod consistent_hash {
             )?;
 
             for _ in 0..2 {
-                let resp = stub.call(&mut context::current(), 'a').await?;
+                let resp = stub.call(&mut context::ClientContext::current(), 'a').await?;
                 assert_eq!(resp, 1);
 
-                let resp = stub.call(&mut context::current(), 'b').await?;
+                let resp = stub.call(&mut context::ClientContext::current(), 'b').await?;
                 assert_eq!(resp, 2);
 
-                let resp = stub.call(&mut context::current(), 'c').await?;
+                let resp = stub.call(&mut context::ClientContext::current(), 'c').await?;
                 assert_eq!(resp, 3);
             }
 

--- a/tarpc/src/client/stub/load_balance.rs
+++ b/tarpc/src/client/stub/load_balance.rs
@@ -20,7 +20,7 @@ mod round_robin {
 
         async fn call(
             &self,
-            ctx: context::Context,
+            ctx: &mut context::Context,
             request: Self::Req,
         ) -> Result<Stub::Resp, RpcError> {
             let next = self.stubs.next();
@@ -119,7 +119,7 @@ mod consistent_hash {
 
         async fn call(
             &self,
-            ctx: context::Context,
+            ctx: &mut context::Context,
             request: Self::Req,
         ) -> Result<Stub::Resp, RpcError> {
             let index = usize::try_from(self.hasher.hash_one(&request) % self.stubs_len).expect(
@@ -200,13 +200,13 @@ mod consistent_hash {
             )?;
 
             for _ in 0..2 {
-                let resp = stub.call(context::current(), 'a').await?;
+                let resp = stub.call(&mut context::current(), 'a').await?;
                 assert_eq!(resp, 1);
 
-                let resp = stub.call(context::current(), 'b').await?;
+                let resp = stub.call(&mut context::current(), 'b').await?;
                 assert_eq!(resp, 2);
 
-                let resp = stub.call(context::current(), 'c').await?;
+                let resp = stub.call(&mut context::current(), 'c').await?;
                 assert_eq!(resp, 3);
             }
 

--- a/tarpc/src/client/stub/mock.rs
+++ b/tarpc/src/client/stub/mock.rs
@@ -30,7 +30,7 @@ where
     type Req = Req;
     type Resp = Resp;
 
-    async fn call(&self, _: context::Context, request: Self::Req) -> Result<Resp, RpcError> {
+    async fn call(&self, _: &mut context::Context, request: Self::Req) -> Result<Resp, RpcError> {
         self.responses
             .get(&request)
             .cloned()

--- a/tarpc/src/client/stub/mock.rs
+++ b/tarpc/src/client/stub/mock.rs
@@ -30,7 +30,7 @@ where
     type Req = Req;
     type Resp = Resp;
 
-    async fn call(&self, _: &mut context::Context, request: Self::Req) -> Result<Resp, RpcError> {
+    async fn call(&self, _: &mut context::ClientContext, request: Self::Req) -> Result<Resp, RpcError> {
         self.responses
             .get(&request)
             .cloned()

--- a/tarpc/src/client/stub/retry.rs
+++ b/tarpc/src/client/stub/retry.rs
@@ -18,7 +18,7 @@ where
 
     async fn call(
         &self,
-        ctx: &mut context::Context,
+        ctx: &mut context::ClientContext,
         request: Self::Req,
     ) -> Result<Stub::Resp, RpcError> {
         let request = Arc::new(request);

--- a/tarpc/src/client/stub/retry.rs
+++ b/tarpc/src/client/stub/retry.rs
@@ -18,7 +18,7 @@ where
 
     async fn call(
         &self,
-        ctx: context::Context,
+        ctx: &mut context::Context,
         request: Self::Req,
     ) -> Result<Stub::Resp, RpcError> {
         let request = Arc::new(request);

--- a/tarpc/src/context.rs
+++ b/tarpc/src/context.rs
@@ -21,7 +21,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 ///
 /// The context should not be stored directly in a server implementation, because the context will
 /// be different for each request in scope.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Context {

--- a/tarpc/src/context.rs
+++ b/tarpc/src/context.rs
@@ -49,6 +49,12 @@ pub struct SharedContext {
 pub struct ServerContext {
     /// Shared context sent from client to server which contains information used by both sides.
     pub shared_context: SharedContext,
+
+    /// Server side extensions that are not seen by the client
+    /// Transport implementations, hooks and service implementations
+    /// can use this to store per-request data, and communicate with eachother.
+    /// Note that this is NOT sent to the client, and they will always see an empty map here.
+    pub server_context: anymap3::Map<dyn core::any::Any + Send + Sync>,
 }
 
 impl ServerContext {
@@ -56,6 +62,7 @@ impl ServerContext {
     pub fn new(shared_context: SharedContext) -> Self {
         Self {
             shared_context,
+            server_context: anymap3::Map::new(),
         }
     }
 
@@ -78,6 +85,7 @@ impl DerefMut for ServerContext {
     }
 }
 
+
 /// Request context that carries request-scoped client side information like deadlines and trace information
 /// as well as any server side extensions defined by the transport, hooks and stubs.
 /// The shared part of the context is sent from client to server, while the client side extensions are only seen on the client side.
@@ -89,6 +97,10 @@ pub struct ClientContext {
     /// Shared context sent from client to server which contains information used by both sides.
     pub shared_context: SharedContext,
 
+    /// Client side extensions that are not seen by the server
+    /// XXX, YYY, and ZZZ can use this to store per-request data, and communicate with eachother.
+    /// Note that this is NOT sent to the server, and they will always see an empty map here.
+    pub client_context: anymap3::Map<dyn core::any::Any + Send + Sync>,
 }
 
 impl ClientContext {
@@ -96,6 +108,7 @@ impl ClientContext {
     pub fn new(shared_context: SharedContext) -> Self {
         Self {
             shared_context,
+            client_context: anymap3::Map::new(),
         }
     }
 

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -125,7 +125,7 @@
 //!
 //! impl World for HelloServer {
 //!     // Each defined rpc generates an async fn that serves the RPC
-//!     async fn hello(self, _: &mut context::Context, name: String) -> String {
+//!     async fn hello(self, _: &mut context::ServerContext, name: String) -> String {
 //!         format!("Hello, {name}!")
 //!     }
 //! }
@@ -158,7 +158,7 @@
 //! # struct HelloServer;
 //! # impl World for HelloServer {
 //!     // Each defined rpc generates an async fn that serves the RPC
-//! #     async fn hello(self, _: &mut context::Context, name: String) -> String {
+//! #     async fn hello(self, _: &mut context::ServerContext, name: String) -> String {
 //! #         format!("Hello, {name}!")
 //! #     }
 //! # }
@@ -184,7 +184,7 @@
 //!     // The client has an RPC method for each RPC defined in the annotated trait. It takes the same
 //!     // args as defined, with the addition of a Context, which is always the first arg. The Context
 //!     // specifies a deadline and trace information which can be helpful in debugging requests.
-//!     let mut context = context::current();
+//!     let mut context = context::ClientContext::current();
 //!     let hello = client.hello(&mut context, "Stim".to_string()).await?;
 //!
 //!     println!("{hello}");
@@ -284,7 +284,7 @@ pub enum ClientMessage<T> {
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Request<T> {
     /// Trace context, deadline, and other cross-cutting concerns.
-    pub context: context::Context,
+    pub context: context::SharedContext,
     /// Uniquely identifies the request across all requests sent over a single channel.
     pub id: u64,
     /// The request body.

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -125,7 +125,7 @@
 //!
 //! impl World for HelloServer {
 //!     // Each defined rpc generates an async fn that serves the RPC
-//!     async fn hello(self, _: context::Context, name: String) -> String {
+//!     async fn hello(self, _: &mut context::Context, name: String) -> String {
 //!         format!("Hello, {name}!")
 //!     }
 //! }
@@ -158,7 +158,7 @@
 //! # struct HelloServer;
 //! # impl World for HelloServer {
 //!     // Each defined rpc generates an async fn that serves the RPC
-//! #     async fn hello(self, _: context::Context, name: String) -> String {
+//! #     async fn hello(self, _: &mut context::Context, name: String) -> String {
 //! #         format!("Hello, {name}!")
 //! #     }
 //! # }
@@ -184,7 +184,8 @@
 //!     // The client has an RPC method for each RPC defined in the annotated trait. It takes the same
 //!     // args as defined, with the addition of a Context, which is always the first arg. The Context
 //!     // specifies a deadline and trace information which can be helpful in debugging requests.
-//!     let hello = client.hello(context::current(), "Stim".to_string()).await?;
+//!     let mut context = context::current();
+//!     let hello = client.hello(&mut context, "Stim".to_string()).await?;
 //!
 //!     println!("{hello}");
 //!
@@ -279,7 +280,7 @@ pub enum ClientMessage<T> {
 }
 
 /// A request from a client to a server.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Request<T> {
     /// Trace context, deadline, and other cross-cutting concerns.

--- a/tarpc/src/server.rs
+++ b/tarpc/src/server.rs
@@ -220,7 +220,7 @@ where
             request.context.trace_context.new_child()
         });
         let entered = span.enter();
-        tracing::info!("ReceiveRequest");
+        tracing::debug!("ReceiveRequest");
         let start = self.in_flight_requests_mut().start_request(
             request.id,
             request.context.deadline,
@@ -450,7 +450,7 @@ where
                 Poll::Ready(Some(request_id)) => {
                     if let Some(span) = self.in_flight_requests_mut().remove_request(request_id) {
                         let _entered = span.enter();
-                        tracing::info!("ResponseCancelled");
+                        tracing::debug!("ResponseCancelled");
                     }
                     Ready
                 }
@@ -545,7 +545,7 @@ where
             .remove_request(response.request_id)
         {
             let _entered = span.enter();
-            tracing::info!("SendResponse");
+            tracing::debug!("SendResponse");
             self.project()
                 .transport
                 .start_send(response)
@@ -650,7 +650,7 @@ where
                 response_guard.cancel = true;
                 {
                     let _entered = span.enter();
-                    tracing::info!("BeginRequest");
+                    tracing::debug!("BeginRequest");
                 }
                 InFlightRequest {
                     request,
@@ -884,13 +884,13 @@ impl<Req, Res> InFlightRequest<Req, Res> {
         let _ = Abortable::new(
             async move {
                 let message = serve.serve(context, message).await;
-                tracing::info!("CompleteRequest");
+                tracing::debug!("CompleteRequest");
                 let response = Response {
                     request_id,
                     message,
                 };
                 let _ = response_tx.send(response).await;
-                tracing::info!("BufferResponse");
+                tracing::debug!("BufferResponse");
             },
             abort_registration,
         )
@@ -1097,7 +1097,7 @@ mod tests {
         }
         impl<Resp> AfterRequest<Resp> for PrintLatency {
             async fn after(&mut self, _: &mut context::Context, _: &mut Result<Resp, ServerError>) {
-                tracing::info!("Elapsed: {:?}", self.start.elapsed());
+                tracing::debug!("Elapsed: {:?}", self.start.elapsed());
             }
         }
 

--- a/tarpc/src/server.rs
+++ b/tarpc/src/server.rs
@@ -76,7 +76,7 @@ pub trait Serve {
     type Resp;
 
     /// Responds to a single request.
-    async fn serve(self, ctx: &mut context::Context, req: Self::Req) -> Result<Self::Resp, ServerError>;
+    async fn serve(self, ctx: &mut context::ServerContext, req: Self::Req) -> Result<Self::Resp, ServerError>;
 }
 
 /// A Serve wrapper around a Fn.
@@ -104,7 +104,7 @@ impl<Req, Resp, F> Copy for ServeFn<Req, Resp, F> where F: Copy {}
 /// Result<Resp, ServerError>>`.
 pub fn serve<Req, Resp, F>(f: F) -> ServeFn<Req, Resp, F>
 where
-    for<'a> F: FnOnce(&'a mut context::Context, Req) -> Pin<Box<dyn Future<Output = Result<Resp, ServerError>> + 'a + Send>>,
+    for<'a> F: FnOnce(&'a mut context::ServerContext, Req) -> Pin<Box<dyn Future<Output = Result<Resp, ServerError>> + 'a + Send>>,
 {
     ServeFn {
         f,
@@ -115,12 +115,12 @@ where
 impl<Req, Resp, F> Serve for ServeFn<Req, Resp, F>
 where
     Req: RequestName,
-    for<'a> F: FnOnce(&'a mut context::Context, Req) -> Pin<Box<dyn Future<Output = Result<Resp, ServerError>> + 'a + Send>>,
+    for<'a> F: FnOnce(&'a mut context::ServerContext, Req) -> Pin<Box<dyn Future<Output = Result<Resp, ServerError>> + 'a + Send>>,
 {
     type Req = Req;
     type Resp = Resp;
 
-    async fn serve(self, ctx: &mut context::Context, req: Req) -> Result<Resp, ServerError> {
+    async fn serve(self, ctx: &mut context::ServerContext, req: Req) -> Result<Resp, ServerError> {
         (self.f)(ctx, req).await
     }
 }
@@ -361,7 +361,7 @@ where
     ///             tokio::spawn(request.execute(serve(|_, i| async move { Ok(i + 1) }.boxed())));
     ///         }
     ///     });
-    ///     let mut context = context::current();
+    ///     let mut context = context::ClientContext::current();
     ///     assert_eq!(client.call(&mut context, 1).await.unwrap(), 2);
     /// }
     /// ```
@@ -402,7 +402,7 @@ where
     ///            .for_each(|response| async move {
     ///                tokio::spawn(response);
     ///            }.boxed()));
-    ///     let mut context = context::current();
+    ///     let mut context = context::ClientContext::current();
     ///     assert_eq!(
     ///         client.call(&mut context, 1).await.unwrap(),
     ///         2);
@@ -752,7 +752,7 @@ where
     ///            .for_each(|response| async move {
     ///                tokio::spawn(response);
     ///            }.boxed()));
-    ///     let mut context = context::current();
+    ///     let mut context = context::ClientContext::current();
     ///     assert_eq!(client.call(&mut context, 1).await.unwrap(), 2);
     /// }
     /// ```
@@ -859,7 +859,7 @@ impl<Req, Res> InFlightRequest<Req, Res> {
     ///             in_flight_request.execute(serve(|_, i| async move { Ok(i + 1) }.boxed())).await;
     ///         }
     ///     });
-    ///     let mut context = context::current();
+    ///     let mut context = context::ClientContext::current();
     ///     assert_eq!(client.call(&mut context, 1).await.unwrap(), 2);
     /// }
     /// ```
@@ -876,15 +876,16 @@ impl<Req, Res> InFlightRequest<Req, Res> {
             span,
             request:
                 Request {
-                    mut context,
+                    context,
                     message,
                     id: request_id,
                 },
         } = self;
         span.record("otel.name", message.name());
+        let mut full_context = context::ServerContext::new(context);
         let _ = Abortable::new(
             async move {
-                let message = serve.serve(&mut context, message).await;
+                let message = serve.serve(&mut full_context, message).await;
                 tracing::debug!("CompleteRequest");
                 let response = Response {
                     request_id,
@@ -978,7 +979,6 @@ mod tests {
         task::Poll,
         time::{Duration, Instant},
     };
-    use tracing_subscriber::filter::FilterExt;
 
     fn test_channel<Req, Resp>() -> (
         Pin<Box<BaseChannel<Req, Resp, UnboundedChannel<ClientMessage<Req>, Response<Resp>>>>>,
@@ -1027,7 +1027,7 @@ mod tests {
 
     fn fake_request<Req>(req: Req) -> ClientMessage<Req> {
         ClientMessage::Request(Request {
-            context: context::current(),
+            context: context::SharedContext::current(),
             id: 0,
             message: req,
         })
@@ -1042,7 +1042,7 @@ mod tests {
     #[tokio::test]
     async fn test_serve() {
         let serve = serve(|_, i| async move { Ok(i) }.boxed());
-        assert_matches!(serve.serve(&mut context::current(), 7).await, Ok(7));
+        assert_matches!(serve.serve(&mut context::ServerContext::current(), 7).await, Ok(7));
     }
 
     #[tokio::test]
@@ -1051,7 +1051,7 @@ mod tests {
         impl<Req> BeforeRequest<Req> for SetDeadline {
             async fn before(
                 &mut self,
-                ctx: &mut context::Context,
+                ctx: &mut context::ServerContext,
                 _: &Req,
             ) -> Result<(), ServerError> {
                 ctx.deadline = self.0;
@@ -1062,12 +1062,12 @@ mod tests {
         let some_time = Instant::now() + Duration::from_secs(37);
         let some_other_time = Instant::now() + Duration::from_secs(83);
 
-        let serve = serve(move |ctx: &mut context::Context, i| async move {
+        let serve = serve(move |ctx: &mut context::ServerContext, i| async move {
             assert_eq!(ctx.deadline, some_time);
             Ok(i)
         }.boxed());
         let deadline_hook = serve.before(SetDeadline(some_time));
-        let mut ctx = context::current();
+        let mut ctx = context::ServerContext::current();
         ctx.deadline = some_other_time;
         deadline_hook.serve(&mut ctx, 7).await?;
         Ok(())
@@ -1090,7 +1090,7 @@ mod tests {
         impl<Req> BeforeRequest<Req> for PrintLatency {
             async fn before(
                 &mut self,
-                _: &mut context::Context,
+                _: &mut context::ServerContext,
                 _: &Req,
             ) -> Result<(), ServerError> {
                 self.start = Instant::now();
@@ -1098,15 +1098,15 @@ mod tests {
             }
         }
         impl<Resp> AfterRequest<Resp> for PrintLatency {
-            async fn after(&mut self, _: &mut context::Context, _: &mut Result<Resp, ServerError>) {
+            async fn after(&mut self, _: &mut context::ServerContext, _: &mut Result<Resp, ServerError>) {
                 tracing::debug!("Elapsed: {:?}", self.start.elapsed());
             }
         }
 
-        let serve = serve(move |_: &mut context::Context, i| async move { Ok(i) }.boxed());
+        let serve = serve(move |_: &mut context::ServerContext, i| async move { Ok(i) }.boxed());
         serve
             .before_and_after(PrintLatency::new())
-            .serve(&mut context::current(), 7)
+            .serve(&mut context::ServerContext::current(), 7)
             .await?;
         Ok(())
     }
@@ -1114,10 +1114,10 @@ mod tests {
     #[tokio::test]
     async fn serve_before_error_aborts_request() -> anyhow::Result<()> {
         let serve = serve(|_, _| async { panic!("Shouldn't get here") }.boxed());
-        let deadline_hook = serve.before(|_: &mut context::Context, _: &i32| async {
+        let deadline_hook = serve.before(|_: &mut context::ServerContext, _: &i32| async {
             Err(ServerError::new(io::ErrorKind::Other, "oops".into()))
         });
-        let resp: Result<i32, _> = deadline_hook.serve(&mut context::current(), 7).await;
+        let resp: Result<i32, _> = deadline_hook.serve(&mut context::ServerContext::current(), 7).await;
         assert_matches!(resp, Err(_));
         Ok(())
     }
@@ -1130,14 +1130,14 @@ mod tests {
             .as_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
         assert_matches!(
             channel.as_mut().start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: ()
             }),
             Err(AlreadyExistsError)
@@ -1153,7 +1153,7 @@ mod tests {
             .as_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1161,7 +1161,7 @@ mod tests {
             .as_mut()
             .start_request(Request {
                 id: 1,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1184,7 +1184,7 @@ mod tests {
             .as_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1213,7 +1213,7 @@ mod tests {
             .as_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1255,7 +1255,7 @@ mod tests {
             .as_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1278,7 +1278,7 @@ mod tests {
             .as_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1343,7 +1343,7 @@ mod tests {
             .channel_pin_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1373,7 +1373,7 @@ mod tests {
             .channel_pin_mut()
             .start_request(Request {
                 id: 1,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1394,7 +1394,7 @@ mod tests {
             .channel_pin_mut()
             .start_request(Request {
                 id: 0,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();
@@ -1413,7 +1413,7 @@ mod tests {
             .channel_pin_mut()
             .start_request(Request {
                 id: 1,
-                context: context::current(),
+                context: context::SharedContext::current(),
                 message: (),
             })
             .unwrap();

--- a/tarpc/src/server/in_flight_requests.rs
+++ b/tarpc/src/server/in_flight_requests.rs
@@ -74,7 +74,7 @@ impl InFlightRequests {
             self.request_data.compact(0.1);
             abort_handle.abort();
             self.deadlines.remove(&deadline_key);
-            tracing::info!("ReceiveCancel");
+            tracing::debug!("ReceiveCancel");
             true
         } else {
             false

--- a/tarpc/src/server/incoming.rs
+++ b/tarpc/src/server/incoming.rs
@@ -65,7 +65,7 @@ where
 ///         BaseChannel::new(server::Config::default(), rx)
 ///     }).execute(serve(|_, i| async move { Ok(i + 1) }.boxed()));
 ///     tokio::spawn(spawn_incoming(incoming));
-///     let mut context = context::current();
+///     let mut context = context::ClientContext::current();
 ///     assert_eq!(client.call(&mut context, 1).await.unwrap(), 2);
 /// }
 /// ```

--- a/tarpc/src/server/incoming.rs
+++ b/tarpc/src/server/incoming.rs
@@ -63,9 +63,10 @@ where
 ///
 ///     let incoming = stream::once(async move {
 ///         BaseChannel::new(server::Config::default(), rx)
-///     }).execute(serve(|_, i| async move { Ok(i + 1) }));
+///     }).execute(serve(|_, i| async move { Ok(i + 1) }.boxed()));
 ///     tokio::spawn(spawn_incoming(incoming));
-///     assert_eq!(client.call(context::current(), 1).await.unwrap(), 2);
+///     let mut context = context::current();
+///     assert_eq!(client.call(&mut context, 1).await.unwrap(), 2);
 /// }
 /// ```
 pub async fn spawn_incoming(

--- a/tarpc/src/server/limits/channels_per_key.rs
+++ b/tarpc/src/server/limits/channels_per_key.rs
@@ -16,7 +16,7 @@ use std::{
     collections::hash_map::Entry, convert::TryFrom, fmt, hash::Hash, marker::Unpin, pin::Pin,
 };
 use tokio::sync::mpsc;
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
 /// An [`Incoming`](crate::server::incoming::Incoming) stream that drops new channels based on
 /// per-key limits.
@@ -198,7 +198,7 @@ where
             Entry::Occupied(mut o) => {
                 let count = o.get().strong_count();
                 if count >= usize::try_from(*self_.channels_per_key).unwrap() {
-                    info!(
+                    debug!(
                         channel_filter_key = %key,
                         open_channels = count,
                         max_open_channels = *self_.channels_per_key,

--- a/tarpc/src/server/limits/requests_per_channel.rs
+++ b/tarpc/src/server/limits/requests_per_channel.rs
@@ -60,7 +60,7 @@ where
             match ready!(self.as_mut().project().inner.poll_next(cx)?) {
                 Some(r) => {
                     let _entered = r.span.enter();
-                    tracing::info!(
+                    tracing::debug!(
                         in_flight_requests = self.as_mut().in_flight_requests(),
                         "ThrottleRequest",
                     );

--- a/tarpc/src/server/request_hook.rs
+++ b/tarpc/src/server/request_hook.rs
@@ -48,7 +48,7 @@ pub trait RequestHook: Serve {
     /// use std::io;
     ///
     /// let serve = serve(|_ctx, i| async move { Ok(i + 1) }.boxed())
-    ///     .before(|_ctx: &mut context::Context, req: &i32| {
+    ///     .before(|_ctx: &mut context::ServerContext, req: &i32| {
     ///         future::ready(
     ///             if *req == 1 {
     ///                 Err(ServerError::new(
@@ -58,7 +58,7 @@ pub trait RequestHook: Serve {
     ///                 Ok(())
     ///             })
     ///     });
-    /// let mut context = context::current();
+    /// let mut context = context::ServerContext::current();
     /// let response = serve.serve(&mut context, 1);
     /// assert!(block_on(response).is_err());
     /// ```
@@ -95,13 +95,13 @@ pub trait RequestHook: Serve {
     ///             Ok(i + 1)
     ///         }
     ///     }.boxed())
-    ///     .after(|_ctx: &mut context::Context, resp: &mut Result<i32, ServerError>| {
+    ///     .after(|_ctx: &mut context::ServerContext, resp: &mut Result<i32, ServerError>| {
     ///         if let Err(e) = resp {
     ///             eprintln!("server error: {e:?}");
     ///         }
     ///         future::ready(())
     ///     });
-    /// let mut context = context::current();
+    /// let mut context = context::ServerContext::current();
     /// let response = serve.serve(&mut context, 1);
     /// assert!(block_on(response).is_err());
     /// ```
@@ -134,7 +134,7 @@ pub trait RequestHook: Serve {
     /// struct PrintLatency(Instant);
     ///
     /// impl<Req> BeforeRequest<Req> for PrintLatency {
-    ///     async fn before(&mut self, _: &mut context::Context, _: &Req) -> Result<(), ServerError> {
+    ///     async fn before(&mut self, _: &mut context::ServerContext, _: &Req) -> Result<(), ServerError> {
     ///         self.0 = Instant::now();
     ///         Ok(())
     ///     }
@@ -143,7 +143,7 @@ pub trait RequestHook: Serve {
     /// impl<Resp> AfterRequest<Resp> for PrintLatency {
     ///     async fn after(
     ///         &mut self,
-    ///         _: &mut context::Context,
+    ///         _: &mut context::ServerContext,
     ///         _: &mut Result<Resp, ServerError>,
     ///     ) {
     ///         tracing::info!("Elapsed: {:?}", self.0.elapsed());
@@ -153,7 +153,7 @@ pub trait RequestHook: Serve {
     /// let serve = serve(|_ctx, i| async move {
     ///         Ok(i + 1)
     ///     }.boxed()).before_and_after(PrintLatency(Instant::now()));
-    ///  let mut context = context::current();
+    /// let mut context = context::ServerContext::current();
     /// let response = serve.serve(&mut context, 1);
     /// assert!(block_on(response).is_ok());
     /// ```

--- a/tarpc/src/server/request_hook/after.rs
+++ b/tarpc/src/server/request_hook/after.rs
@@ -59,14 +59,14 @@ where
 
     async fn serve(
         self,
-        mut ctx: context::Context,
+        ctx: &mut context::Context,
         req: Serv::Req,
     ) -> Result<Serv::Resp, ServerError> {
         let ServeThenHook {
             serve, mut hook, ..
         } = self;
         let mut resp = serve.serve(ctx, req).await;
-        hook.after(&mut ctx, &mut resp).await;
+        hook.after(ctx, &mut resp).await;
         resp
     }
 }

--- a/tarpc/src/server/request_hook/after.rs
+++ b/tarpc/src/server/request_hook/after.rs
@@ -15,15 +15,15 @@ pub trait AfterRequest<Resp> {
     /// The function that is called after request execution.
     ///
     /// The hook can modify the request context and the response.
-    async fn after(&mut self, ctx: &mut context::Context, resp: &mut Result<Resp, ServerError>);
+    async fn after(&mut self, ctx: &mut context::ServerContext, resp: &mut Result<Resp, ServerError>);
 }
 
 impl<F, Fut, Resp> AfterRequest<Resp> for F
 where
-    F: FnMut(&mut context::Context, &mut Result<Resp, ServerError>) -> Fut,
+    F: FnMut(&mut context::ServerContext, &mut Result<Resp, ServerError>) -> Fut,
     Fut: Future<Output = ()>,
 {
-    async fn after(&mut self, ctx: &mut context::Context, resp: &mut Result<Resp, ServerError>) {
+    async fn after(&mut self, ctx: &mut context::ServerContext, resp: &mut Result<Resp, ServerError>) {
         self(ctx, resp).await
     }
 }
@@ -59,7 +59,7 @@ where
 
     async fn serve(
         self,
-        ctx: &mut context::Context,
+        ctx: &mut context::ServerContext,
         req: Serv::Req,
     ) -> Result<Serv::Resp, ServerError> {
         let ServeThenHook {

--- a/tarpc/src/server/request_hook/before_and_after.rs
+++ b/tarpc/src/server/request_hook/before_and_after.rs
@@ -46,13 +46,13 @@ where
     type Req = Req;
     type Resp = Resp;
 
-    async fn serve(self, mut ctx: context::Context, req: Req) -> Result<Serv::Resp, ServerError> {
+    async fn serve(self, ctx: &mut context::Context, req: Req) -> Result<Serv::Resp, ServerError> {
         let HookThenServeThenHook {
             serve, mut hook, ..
         } = self;
-        hook.before(&mut ctx, &req).await?;
+        hook.before(ctx, &req).await?;
         let mut resp = serve.serve(ctx, req).await;
-        hook.after(&mut ctx, &mut resp).await;
+        hook.after(ctx, &mut resp).await;
         resp
     }
 }

--- a/tarpc/src/server/request_hook/before_and_after.rs
+++ b/tarpc/src/server/request_hook/before_and_after.rs
@@ -46,7 +46,7 @@ where
     type Req = Req;
     type Resp = Resp;
 
-    async fn serve(self, ctx: &mut context::Context, req: Req) -> Result<Serv::Resp, ServerError> {
+    async fn serve(self, ctx: &mut context::ServerContext, req: Req) -> Result<Serv::Resp, ServerError> {
         let HookThenServeThenHook {
             serve, mut hook, ..
         } = self;

--- a/tarpc/src/server/testing.rs
+++ b/tarpc/src/server/testing.rs
@@ -92,7 +92,7 @@ impl<Req, Resp> FakeChannel<io::Result<TrackedRequest<Req>>, Response<Resp>> {
         let (request_cancellation, _) = cancellations();
         self.stream.push_back(Ok(TrackedRequest {
             request: Request {
-                context: context::Context {
+                context: context::SharedContext {
                     deadline: Instant::now(),
                     trace_context: Default::default(),
                 },

--- a/tarpc/src/transport/channel.rs
+++ b/tarpc/src/transport/channel.rs
@@ -198,7 +198,7 @@ mod tests {
                             format!("{request:?} is not an int"),
                         )
                     })
-                }))
+                }.boxed()))
                 .for_each(|channel| async move {
                     tokio::spawn(channel.for_each(|response| response));
                 }),
@@ -206,8 +206,8 @@ mod tests {
 
         let client = client::new(client::Config::default(), client_channel).spawn();
 
-        let response1 = client.call(context::current(), "123".into()).await;
-        let response2 = client.call(context::current(), "abc".into()).await;
+        let response1 = client.call(&mut context::current(), "123".into()).await;
+        let response2 = client.call(&mut context::current(), "abc".into()).await;
 
         trace!("response1: {:?}, response2: {:?}", response1, response2);
 

--- a/tarpc/src/transport/channel.rs
+++ b/tarpc/src/transport/channel.rs
@@ -206,8 +206,8 @@ mod tests {
 
         let client = client::new(client::Config::default(), client_channel).spawn();
 
-        let response1 = client.call(&mut context::current(), "123".into()).await;
-        let response2 = client.call(&mut context::current(), "abc".into()).await;
+        let response1 = client.call(&mut context::ClientContext::current(), "123".into()).await;
+        let response2 = client.call(&mut context::ClientContext::current(), "abc".into()).await;
 
         trace!("response1: {:?}, response2: {:?}", response1, response2);
 

--- a/tarpc/tests/dataservice.rs
+++ b/tarpc/tests/dataservice.rs
@@ -22,7 +22,7 @@ pub trait ColorProtocol {
 struct ColorServer;
 
 impl ColorProtocol for ColorServer {
-    async fn get_opposite_color(self, _: &mut context::Context, color: TestData) -> TestData {
+    async fn get_opposite_color(self, _: &mut context::ServerContext, color: TestData) -> TestData {
         match color {
             TestData::White => TestData::Black,
             TestData::Black => TestData::White,
@@ -53,7 +53,7 @@ async fn test_call() -> anyhow::Result<()> {
     let client = ColorProtocolClient::new(client::Config::default(), transport).spawn();
 
     let color = client
-        .get_opposite_color(&mut context::current(), TestData::White)
+        .get_opposite_color(&mut context::ClientContext::current(), TestData::White)
         .await?;
     assert_eq!(color, TestData::Black);
 

--- a/tarpc/tests/dataservice.rs
+++ b/tarpc/tests/dataservice.rs
@@ -22,7 +22,7 @@ pub trait ColorProtocol {
 struct ColorServer;
 
 impl ColorProtocol for ColorServer {
-    async fn get_opposite_color(self, _: context::Context, color: TestData) -> TestData {
+    async fn get_opposite_color(self, _: &mut context::Context, color: TestData) -> TestData {
         match color {
             TestData::White => TestData::Black,
             TestData::Black => TestData::White,
@@ -53,7 +53,7 @@ async fn test_call() -> anyhow::Result<()> {
     let client = ColorProtocolClient::new(client::Config::default(), transport).spawn();
 
     let color = client
-        .get_opposite_color(context::current(), TestData::White)
+        .get_opposite_color(&mut context::current(), TestData::White)
         .await?;
     assert_eq!(color, TestData::Black);
 

--- a/tarpc/tests/service_functional.rs
+++ b/tarpc/tests/service_functional.rs
@@ -22,11 +22,11 @@ trait Service {
 struct Server;
 
 impl Service for Server {
-    async fn add(self, _: context::Context, x: i32, y: i32) -> i32 {
+    async fn add(self, _: &mut context::Context, x: i32, y: i32) -> i32 {
         x + y
     }
 
-    async fn hey(self, _: context::Context, name: String) -> String {
+    async fn hey(self, _: &mut context::Context, name: String) -> String {
         format!("Hey, {name}.")
     }
 }
@@ -38,10 +38,10 @@ async fn sequential() {
     let channel = BaseChannel::with_defaults(rx);
     tokio::spawn(
         channel
-            .execute(tarpc::server::serve(|_, i: u32| async move { Ok(i + 1) }))
+            .execute(tarpc::server::serve(|_, i: u32| async move { Ok(i + 1) }.boxed()))
             .for_each(|response| response),
     );
-    assert_eq!(client.call(context::current(), 1).await.unwrap(), 2);
+    assert_eq!(client.call(&mut context::current(), 1).await.unwrap(), 2);
 }
 
 #[tokio::test]
@@ -55,7 +55,7 @@ async fn dropped_channel_aborts_in_flight_requests() -> anyhow::Result<()> {
     struct LoopServer;
 
     impl Loop for LoopServer {
-        async fn r#loop(self, _: context::Context) {
+        async fn r#loop(self, _: &mut context::Context) {
             loop {
                 futures::pending!();
             }
@@ -73,7 +73,7 @@ async fn dropped_channel_aborts_in_flight_requests() -> anyhow::Result<()> {
 
         let mut ctx = context::current();
         ctx.deadline = Instant::now() + Duration::from_secs(60 * 60);
-        let _ = client.r#loop(ctx).await;
+        let _ = client.r#loop(&mut ctx).await;
     });
 
     let mut requests = BaseChannel::with_defaults(rx).requests();
@@ -112,9 +112,9 @@ async fn serde_tcp() -> anyhow::Result<()> {
     let transport = serde_transport::tcp::connect(addr, Json::default).await?;
     let client = ServiceClient::new(client::Config::default(), transport).spawn();
 
-    assert_matches!(client.add(context::current(), 1, 2).await, Ok(3));
+    assert_matches!(client.add(&mut context::current(), 1, 2).await, Ok(3));
     assert_matches!(
-        client.hey(context::current(), "Tim".to_string()).await,
+        client.hey(&mut context::current(), "Tim".to_string()).await,
         Ok(ref s) if s == "Hey, Tim."
     );
 
@@ -145,8 +145,8 @@ async fn serde_uds() -> anyhow::Result<()> {
     let client = ServiceClient::new(client::Config::default(), transport).spawn();
 
     // Save results using socket so we can clean the socket even if our test assertions fail
-    let res1 = client.add(context::current(), 1, 2).await;
-    let res2 = client.hey(context::current(), "Tim".to_string()).await;
+    let res1 = client.add(&mut context::current(), 1, 2).await;
+    let res2 = client.hey(&mut context::current(), "Tim".to_string()).await;
 
     assert_matches!(res1, Ok(3));
     assert_matches!(res2, Ok(ref s) if s == "Hey, Tim.");
@@ -169,12 +169,15 @@ async fn concurrent() -> anyhow::Result<()> {
 
     let client = ServiceClient::new(client::Config::default(), tx).spawn();
 
-    let req1 = client.add(context::current(), 1, 2);
-    let req2 = client.add(context::current(), 3, 4);
-    let req3 = client.hey(context::current(), "Tim".to_string());
+    let mut context = context::current();
 
+    let req1 = client.add(&mut context, 1, 2);
     assert_matches!(req1.await, Ok(3));
+
+    let req2 = client.add(&mut context, 3, 4);
     assert_matches!(req2.await, Ok(7));
+
+    let req3 = client.hey(&mut context, "Tim".to_string());
     assert_matches!(req3.await, Ok(ref s) if s == "Hey, Tim.");
 
     Ok(())
@@ -195,9 +198,13 @@ async fn concurrent_join() -> anyhow::Result<()> {
 
     let client = ServiceClient::new(client::Config::default(), tx).spawn();
 
-    let req1 = client.add(context::current(), 1, 2);
-    let req2 = client.add(context::current(), 3, 4);
-    let req3 = client.hey(context::current(), "Tim".to_string());
+    let mut context1 = context::current();
+    let mut context2 = context::current();
+    let mut context3 = context::current();
+
+    let req1 = client.add(&mut context1, 1, 2);
+    let req2 = client.add(&mut context2, 3, 4);
+    let req3 = client.hey(&mut context3, "Tim".to_string());
 
     let (resp1, resp2, resp3) = join!(req1, req2, req3);
     assert_matches!(resp1, Ok(3));
@@ -225,8 +232,11 @@ async fn concurrent_join_all() -> anyhow::Result<()> {
 
     let client = ServiceClient::new(client::Config::default(), tx).spawn();
 
-    let req1 = client.add(context::current(), 1, 2);
-    let req2 = client.add(context::current(), 3, 4);
+    let mut context1 = context::current();
+    let mut context2 = context::current();
+
+    let req1 = client.add(&mut context1, 1, 2);
+    let req2 = client.add(&mut context2, 3, 4);
 
     let responses = join_all(vec![req1, req2]).await;
     assert_matches!(responses[0], Ok(3));
@@ -245,7 +255,7 @@ async fn counter() -> anyhow::Result<()> {
     struct CountService(u32);
 
     impl Counter for &mut CountService {
-        async fn count(self, _: context::Context) -> u32 {
+        async fn count(self, _: &mut context::Context) -> u32 {
             self.0 += 1;
             self.0
         }
@@ -262,8 +272,8 @@ async fn counter() -> anyhow::Result<()> {
     });
 
     let client = CounterClient::new(client::Config::default(), tx).spawn();
-    assert_matches!(client.count(context::current()).await, Ok(1));
-    assert_matches!(client.count(context::current()).await, Ok(2));
+    assert_matches!(client.count(&mut context::current()).await, Ok(1));
+    assert_matches!(client.count(&mut context::current()).await, Ok(2));
 
     Ok(())
 }

--- a/tarpc/tests/service_functional.rs
+++ b/tarpc/tests/service_functional.rs
@@ -22,11 +22,11 @@ trait Service {
 struct Server;
 
 impl Service for Server {
-    async fn add(self, _: &mut context::Context, x: i32, y: i32) -> i32 {
+    async fn add(self, _: &mut context::ServerContext, x: i32, y: i32) -> i32 {
         x + y
     }
 
-    async fn hey(self, _: &mut context::Context, name: String) -> String {
+    async fn hey(self, _: &mut context::ServerContext, name: String) -> String {
         format!("Hey, {name}.")
     }
 }
@@ -41,7 +41,7 @@ async fn sequential() {
             .execute(tarpc::server::serve(|_, i: u32| async move { Ok(i + 1) }.boxed()))
             .for_each(|response| response),
     );
-    assert_eq!(client.call(&mut context::current(), 1).await.unwrap(), 2);
+    assert_eq!(client.call(&mut context::ClientContext::current(), 1).await.unwrap(), 2);
 }
 
 #[tokio::test]
@@ -55,7 +55,7 @@ async fn dropped_channel_aborts_in_flight_requests() -> anyhow::Result<()> {
     struct LoopServer;
 
     impl Loop for LoopServer {
-        async fn r#loop(self, _: &mut context::Context) {
+        async fn r#loop(self, _: &mut context::ServerContext) {
             loop {
                 futures::pending!();
             }
@@ -71,7 +71,7 @@ async fn dropped_channel_aborts_in_flight_requests() -> anyhow::Result<()> {
     tokio::spawn(async move {
         let client = LoopClient::new(client::Config::default(), tx).spawn();
 
-        let mut ctx = context::current();
+        let mut ctx = context::ClientContext::current();
         ctx.deadline = Instant::now() + Duration::from_secs(60 * 60);
         let _ = client.r#loop(&mut ctx).await;
     });
@@ -112,9 +112,9 @@ async fn serde_tcp() -> anyhow::Result<()> {
     let transport = serde_transport::tcp::connect(addr, Json::default).await?;
     let client = ServiceClient::new(client::Config::default(), transport).spawn();
 
-    assert_matches!(client.add(&mut context::current(), 1, 2).await, Ok(3));
+    assert_matches!(client.add(&mut context::ClientContext::current(), 1, 2).await, Ok(3));
     assert_matches!(
-        client.hey(&mut context::current(), "Tim".to_string()).await,
+        client.hey(&mut context::ClientContext::current(), "Tim".to_string()).await,
         Ok(ref s) if s == "Hey, Tim."
     );
 
@@ -145,8 +145,8 @@ async fn serde_uds() -> anyhow::Result<()> {
     let client = ServiceClient::new(client::Config::default(), transport).spawn();
 
     // Save results using socket so we can clean the socket even if our test assertions fail
-    let res1 = client.add(&mut context::current(), 1, 2).await;
-    let res2 = client.hey(&mut context::current(), "Tim".to_string()).await;
+    let res1 = client.add(&mut context::ClientContext::current(), 1, 2).await;
+    let res2 = client.hey(&mut context::ClientContext::current(), "Tim".to_string()).await;
 
     assert_matches!(res1, Ok(3));
     assert_matches!(res2, Ok(ref s) if s == "Hey, Tim.");
@@ -169,7 +169,7 @@ async fn concurrent() -> anyhow::Result<()> {
 
     let client = ServiceClient::new(client::Config::default(), tx).spawn();
 
-    let mut context = context::current();
+    let mut context = context::ClientContext::current();
 
     let req1 = client.add(&mut context, 1, 2);
     assert_matches!(req1.await, Ok(3));
@@ -198,9 +198,9 @@ async fn concurrent_join() -> anyhow::Result<()> {
 
     let client = ServiceClient::new(client::Config::default(), tx).spawn();
 
-    let mut context1 = context::current();
-    let mut context2 = context::current();
-    let mut context3 = context::current();
+    let mut context1 = context::ClientContext::current();
+    let mut context2 = context::ClientContext::current();
+    let mut context3 = context::ClientContext::current();
 
     let req1 = client.add(&mut context1, 1, 2);
     let req2 = client.add(&mut context2, 3, 4);
@@ -232,8 +232,8 @@ async fn concurrent_join_all() -> anyhow::Result<()> {
 
     let client = ServiceClient::new(client::Config::default(), tx).spawn();
 
-    let mut context1 = context::current();
-    let mut context2 = context::current();
+    let mut context1 = context::ClientContext::current();
+    let mut context2 = context::ClientContext::current();
 
     let req1 = client.add(&mut context1, 1, 2);
     let req2 = client.add(&mut context2, 3, 4);
@@ -255,7 +255,7 @@ async fn counter() -> anyhow::Result<()> {
     struct CountService(u32);
 
     impl Counter for &mut CountService {
-        async fn count(self, _: &mut context::Context) -> u32 {
+        async fn count(self, _: &mut context::ServerContext) -> u32 {
             self.0 += 1;
             self.0
         }
@@ -272,8 +272,8 @@ async fn counter() -> anyhow::Result<()> {
     });
 
     let client = CounterClient::new(client::Config::default(), tx).spawn();
-    assert_matches!(client.count(&mut context::current()).await, Ok(1));
-    assert_matches!(client.count(&mut context::current()).await, Ok(2));
+    assert_matches!(client.count(&mut context::ClientContext::current()).await, Ok(1));
+    assert_matches!(client.count(&mut context::ClientContext::current()).await, Ok(2));
 
     Ok(())
 }


### PR DESCRIPTION
Third and final PR of the solution to https://github.com/google/tarpc/issues/392, and builds on top of https://github.com/google/tarpc/pull/539 and https://github.com/google/tarpc/pull/540.

The diff view will show both PRs, please take a look at the commit view for a clean diff.

This adds an anymap to both server and client contexts, that can be used for saving state, or communication between hooks, service implementation and transport.